### PR TITLE
リクエスト毎に１秒のスリープをいれる

### DIFF
--- a/lib/surveymonkey.rb
+++ b/lib/surveymonkey.rb
@@ -64,11 +64,15 @@ module Surveymonkey
         pagination_field = PaginatedMethods.fetch(method_name, nil)
         if pagination_field
           $log.info sprintf("calling method '%s' with pagination, page size %i", method_name, page_size)
-          paginate_request(method_name, pagination_field, page_size, method_params)
+          resp = paginate_request(method_name, pagination_field, page_size, method_params)
         else
           $log.info sprintf("calling method '%s' without pagination", method_name)
-          Surveymonkey::Request.new(method_name.to_s, method_params).execute
+          resp = Surveymonkey::Request.new(method_name.to_s, method_params).execute
         end
+
+        # This is tentative deal, because of SurveyMoneky API allows only 2 times/sec.
+        sleep 1
+        resp
 
       rescue TypeError => e
         $log.fatal sprintf("%s: method parameters must be a hash", __method__)

--- a/lib/surveymonkey/api.rb
+++ b/lib/surveymonkey/api.rb
@@ -15,7 +15,7 @@ class Surveymonkey::API
   Api_version = 'v2'
 
   ##
-  # Hash defining the methods in the SurveyMonkey API.  Current as of 2015-05-05.
+  # Hash defining the methods in the SurveyMonkey API.  Current as of 2015-12-14.
 
   Api_methods = {
     'create_flow' => {
@@ -50,6 +50,9 @@ class Surveymonkey::API
     },
     'get_user_details' => {
       'path' => '/v2/user/get_user_details',
+    },
+    'create_recipients' => {
+      'path' => '/v2/collectors/create_recipients',
     },
   }
 


### PR DESCRIPTION
# Why

SurveyMonkeyの秒間クォータ制限回避のため。
# 備考

SurveyMonkey APIでは`2times/sec`という制限があり、超えた場合403が返ってくる。
